### PR TITLE
Improve help window toggle functionality

### DIFF
--- a/lua/dooing/ui.lua
+++ b/lua/dooing/ui.lua
@@ -173,7 +173,7 @@ create_help_window = function()
 	end
 
 	vim.keymap.set("n", config.options.keymaps.close_window, close_help, { buffer = help_buf_id, nowait = true })
-	vim.keymap.set("n", config.options.keymaps.toggle_help, close_help, { buffer = buf_id, nowait = true })
+	vim.keymap.set("n", config.options.keymaps.toggle_help, close_help, { buffer = help_buf_id, nowait = true })
 end
 
 -- Creates and manages the tags window


### PR DESCRIPTION
can't reopen help window after closing it with `?` `cuz after closing help buffer with buf_id the help buffer no longer existed, but the keymap was tied to the main buffer (buf_id) pressing the key again in the main buffer would try to close a non-existent help window(doing nothing)

modified key mapping to use help_buf_id instead of buf_id for closing the help buffer
