### PR TITLE
Change: use X instead of Space for toggle prioritization

### DIFF
--- a/lua/dooing/ui.lua
+++ b/lua/dooing/ui.lua
@@ -710,7 +710,7 @@ function M.new_todo()
 					border = "rounded",
 					title = " Select Priorities ",
 					title_pos = "center",
-					footer = " <Space>: toggle | <Enter>: confirm ",
+					footer = "  <x> : toggle | <Enter>: confirm ",
 					footer_pos = "center",
 				})
 
@@ -719,7 +719,7 @@ function M.new_todo()
 				vim.api.nvim_buf_set_option(select_buf, "modifiable", false)
 
 				-- Add keymaps for selection
-				vim.keymap.set("n", "<Space>", function()
+				vim.keymap.set("n", "x", function()
 					local cursor = vim.api.nvim_win_get_cursor(select_win)
 					local line_num = cursor[1]
 					local current_line = vim.api.nvim_buf_get_lines(select_buf, line_num - 1, line_num, false)[1]


### PR DESCRIPTION
This pull request remaps the Toggle command in Select priorities tab to X instead of Space, to ensure consistency between the main to-do tab and the Select priorities tab