### PR TITLE
Adding duplicates removal functionality.

### DIFF
--- a/lua/dooing/config.lua
+++ b/lua/dooing/config.lua
@@ -66,7 +66,8 @@ M.defaults = {
 		edit_tag = "e",
 		delete_tag = "d",
 		search_todos = "/",
-		toggle_priority = "<Space>"
+		remove_duplicates = "<leader>D",
+		toggle_priority = "<Space>",
 	},
 	calendar = {
 		language = "en",

--- a/lua/dooing/state.lua
+++ b/lua/dooing/state.lua
@@ -59,7 +59,6 @@ function M.toggle_todo(index)
 end
 
 -- Parse date string in the format MM/DD/YYYY
--- @TODO: handle `format` -> a custom date format
 local function parse_date(date_str, format)
 	local month, day, year = date_str:match("^(%d%d?)/(%d%d?)/(%d%d%d%d)$")
 
@@ -161,6 +160,35 @@ function M.delete_completed()
 	end
 	M.todos = remaining_todos
 	save_todos()
+end
+
+-- Helper function for hashing a todo object
+local function gen_hash(todo)
+	local todo_string = vim.inspect(todo)
+	return vim.fn.sha256(todo_string)
+end
+
+-- Remove duplicate todos based on hash
+function M.remove_duplicates()
+	local seen = {}
+	local uniques = {}
+	local removed = 0
+
+	for _, todo in ipairs(M.todos) do
+		if type(todo) == "table" then
+			local hash = gen_hash(todo)
+			if not seen[hash] then
+				seen[hash] = true
+				table.insert(uniques, todo)
+			else
+				removed = removed + 1
+			end
+		end
+	end
+
+	M.todos = uniques
+	save_todos()
+	return tostring(removed)
 end
 
 -- Calculate priority score for a todo item

--- a/lua/dooing/ui.lua
+++ b/lua/dooing/ui.lua
@@ -537,6 +537,7 @@ local function create_window()
 	set_conditional_keymap("edit_todo", edit_todo, { buffer = buf_id, nowait = true })
 	set_conditional_keymap("add_due_date", add_due_date, { buffer = buf_id, nowait = true })
 	set_conditional_keymap("remove_due_date", remove_due_date, { buffer = buf_id, nowait = true })
+	set_conditional_keymap("remove_duplicates", M.remove_duplicates, { buffer = buf_id, nowait = true })
 	set_conditional_keymap("search_todos", create_search_window, { buffer = buf_id, nowait = true })
 	set_conditional_keymap("clear_filter", function()
 		state.set_filter(nil)
@@ -860,6 +861,13 @@ end
 -- Deletes all completed todos
 function M.delete_completed()
 	state.delete_completed()
+	M.render_todos()
+end
+
+-- Delete all duplicated todos
+function M.remove_duplicates()
+	local dups = state.remove_duplicates()
+	vim.notify("Removed " .. dups .. " duplicates.", vim.log.levels.INFO)
 	M.render_todos()
 end
 


### PR DESCRIPTION
This PR introduces a feature that allows users to remove duplicate todos based on their content. 
The duplicate todos are identified using a hash of the todo objects.

- The hash is not just based on the text, but also includes other properties of the todo. 
- Duplicates are removed while retaining only the unique ones.