### PR TITLE
Enable Syntax Highlighting in Scratchpad

### DIFF
--- a/lua/dooing/config.lua
+++ b/lua/dooing/config.lua
@@ -99,6 +99,9 @@ M.defaults = {
 			close_calendar = "q",
 		},
 	},
+  scratchpad = {
+    syntax_highlight = "markdown",
+  },
 }
 
 M.options = {}

--- a/lua/dooing/ui.lua
+++ b/lua/dooing/ui.lua
@@ -681,9 +681,22 @@ local function open_todo_scratchpad()
 		todo.notes = ""
 	end
 
+  local function is_valid_filetype(filetype)
+      local syntax_file = vim.fn.globpath(vim.o.runtimepath, "syntax/" .. filetype .. ".vim")
+      return syntax_file ~= ""
+  end
+
 	local scratch_buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_option(scratch_buf, "buftype", "acwrite")
 	vim.api.nvim_buf_set_option(scratch_buf, "swapfile", false)
+
+  local syntax_highlight = config.options.scratchpad.syntax_highlight
+  if not is_valid_filetype(syntax_highlight) then
+      vim.notify("Invalid scratchpad syntax highlight '" .. syntax_highlight .. "'. Using default 'markdown'.", vim.log.levels.WARN)
+      syntax_highlight = "markdown"
+  end
+
+  vim.api.nvim_buf_set_option(scratch_buf, "filetype", syntax_highlight)
 
 	local ui = vim.api.nvim_list_uis()[1]
 	local width = math.floor(ui.width * 0.6)


### PR DESCRIPTION
Hi, I hope you're doing well!

I’ve added a minor feature to improve the scratchpad experience. Specifically, I’ve enabled syntax highlighting for the scratchpad, which was outlined in #37. This allows the user to have a better editing experience with proper syntax highlighting.

By default, the syntax highlighting is set to markdown, but it will also fall back to markdown in case an invalid syntax is provided.

Here’s the updated behavior:

- Syntax highlighting is now enabled for the scratchpad.
- If no syntax is specified or an invalid one is provided, it will default to **markdown**.

_Note: I don't know if that behavior of making markdown a default is desirable. If preferred, the default can be set to none to avoid any syntax highlighting by default._

![image](https://github.com/user-attachments/assets/0652e5a5-ade7-44ae-810e-70378322a40e)

![image](https://github.com/user-attachments/assets/141c16b5-b27b-4e3e-8855-0c0c0ab898f6)

What do you think about it?