### PR TITLE
fix: update deadline timestamp to save as 23:59:59

### DIFF
--- a/lua/dooing/state.lua
+++ b/lua/dooing/state.lua
@@ -121,6 +121,12 @@ function M.add_due_date(index, date_str)
 
 	local timestamp, err = parse_date(date_str)
 	if timestamp then
+    local date_table = os.date("*t", timestamp)
+    date_table.hour = 23
+    date_table.min = 59
+    date_table.sec = 59
+    timestamp = os.time(date_table)
+
 		M.todos[index].due_at = timestamp
 		M.save_todos()
 		return true


### PR DESCRIPTION
The system previously saved the deadline timestamp as 00:00:00 of the specified date, which excluded the entire day from the deadline. This commit updates the logic to save the timestamp as 23:59:59, ensuring that users can fully utilize the day of the deadline as expected.

- Updated logic to save deadline timestamps as 23:59:59.
- Added tests to verify the behavior.