### PR TITLE
fix: improve cursor position after adding todos with and without prio…

### DIFF
--- a/lua/dooing/ui.lua
+++ b/lua/dooing/ui.lua
@@ -1482,19 +1482,24 @@ function M.new_todo()
 					state.add_todo(input, priorities_to_add)
 					M.render_todos()
 
-					-- Position cursor at the new todo
-					local total_lines = vim.api.nvim_buf_line_count(buf_id)
-					local target_line = nil
-					for i = 1, total_lines do
-						local line = vim.api.nvim_buf_get_lines(buf_id, i - 1, i, false)[1]
-						if line:match("^%s+" .. config.options.formatting.done.icon .. ".*~") then
-							target_line = i - 1
-							break
+					-- Make sure we're focusing on the main window
+					if win_id and vim.api.nvim_win_is_valid(win_id) then
+						vim.api.nvim_set_current_win(win_id)
+						
+						-- Position cursor at the new todo
+						local total_lines = vim.api.nvim_buf_line_count(buf_id)
+						local target_line = nil
+						for i = 1, total_lines do
+							local line = vim.api.nvim_buf_get_lines(buf_id, i - 1, i, false)[1]
+							if line:match("^%s+" .. config.options.formatting.pending.icon .. ".*" .. vim.pesc(input)) then
+								target_line = i
+								break
+							end
 						end
-					end
 
-					if target_line and win_id and vim.api.nvim_win_is_valid(win_id) then
-						vim.api.nvim_win_set_cursor(win_id, { target_line, 0 })
+						if target_line and win_id and vim.api.nvim_win_is_valid(win_id) then
+							vim.api.nvim_win_set_cursor(win_id, { target_line, 0 })
+						end
 					end
 				end, { buffer = select_buf, nowait = true })
 
@@ -1519,6 +1524,26 @@ function M.new_todo()
 				-- If prioritization is disabled, just add the todo without priority
 				state.add_todo(input)
 				M.render_todos()
+				
+				-- Make sure we're focusing on the main window
+				if win_id and vim.api.nvim_win_is_valid(win_id) then
+					vim.api.nvim_set_current_win(win_id)
+					
+					-- Position cursor at the new todo
+					local total_lines = vim.api.nvim_buf_line_count(buf_id)
+					local target_line = nil
+					for i = 1, total_lines do
+						local line = vim.api.nvim_buf_get_lines(buf_id, i - 1, i, false)[1]
+						if line:match("^%s+" .. config.options.formatting.pending.icon .. ".*" .. vim.pesc(input)) then
+							target_line = i
+							break
+						end
+					end
+					
+					if target_line and win_id and vim.api.nvim_win_is_valid(win_id) then
+						vim.api.nvim_win_set_cursor(win_id, { target_line, 0 })
+					end
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
## Description
This PR/issue addresses problems with cursor positioning after adding todos in the application. The changes improve the user experience by ensuring proper focus and cursor placement after todo creation operations.

## Changes Made
The fix contains two main parts:

1. When adding todos WITH priority:
   - Added `vim.api.nvim_set_current_win(win_id)` to ensure focus returns to the main window
   - Improved logic for finding newly added todos by:
     - Using `config.options.formatting.pending.icon` instead of `done.icon`
     - Matching against the input text to find the correct todo item
     - Using `vim.pesc()` to escape special characters in the input text
to prevent regex matching errors

2. When adding todos WITHOUT priority:
   - Implemented similar focus setting and cursor positioning logic
   - Ensured proper cursor placement even when no priority is set for the todo item

## Motivation
These changes improve the user experience by making sure that after adding a todo item, the cursor is correctly positioned at the newly added item, allowing for smoother workflow and better usability.

## Testing
I've tested this fix with various todo items (with and without special characters) and confirmed that the cursor is now properly positioned in both scenarios.