### PR TITLE
feat: windows compatibility for local project todos

### DIFF
--- a/lua/dooing/state.lua
+++ b/lua/dooing/state.lua
@@ -41,6 +41,8 @@ end
 
 -- Get git root directory
 function M.get_git_root()
+	local devnull = (vim.loop.os_uname().sysname == "Windows_NT") and "NUL"
+		or "/dev/null"
 	local handle = io.popen("git rev-parse --show-toplevel 2>/dev/null")
 	if not handle then
 		return nil


### PR DESCRIPTION
on unix systems you'd usually use /dev/null but on windows it's NUL