### PR TITLE
fix: cancel input prompt error

### DIFF
--- a/lua/dooing/ui/actions.lua
+++ b/lua/dooing/ui/actions.lua
@@ -196,6 +196,10 @@ end
 -- Creates a new todo item
 function M.new_todo()
 	vim.ui.input({ prompt = "New to-do: " }, function(input)
+		if not input or input == "" then
+			return
+		end
+
 		input = input:gsub("\n", " ")
 		if input and input ~= "" then
 			-- Check if priorities are configured


### PR DESCRIPTION
When you make a new todo, it will call vim.fn.input and there is one code where it will do string.gsub but sometimes the user cancels the prompt process so it will become nil. So I am here to propose a solution for that by checking if it is nil and is an empty string.