### PR TITLE
fix: restore focus to original window when closing dooing

### DIFF
--- a/lua/dooing/ui/constants.lua
+++ b/lua/dooing/ui/constants.lua
@@ -19,4 +19,7 @@ M.tag_buf_id = nil
 M.search_win_id = nil
 M.search_buf_id = nil
 
+-- Window to restore focus to when closing dooing
+M.previous_win = nil
+
 return M 

--- a/lua/dooing/ui/window.lua
+++ b/lua/dooing/ui/window.lua
@@ -97,6 +97,12 @@ end
 
 -- Creates and configures the main todo window
 function M.create_window()
+	-- Save the window the user was in before opening dooing
+	-- Only save if we're not already inside a dooing window (e.g. toggling global↔project)
+	if constants.win_id == nil or not vim.api.nvim_win_is_valid(constants.win_id) then
+		constants.previous_win = vim.api.nvim_get_current_win()
+	end
+
 	local ui = vim.api.nvim_list_uis()[1]
 	local width = config.options.window.width
 	local height = config.options.window.height
@@ -202,6 +208,12 @@ function M.close_window()
 		constants.win_id = nil
 		constants.buf_id = nil
 	end
+
+	-- Restore focus to the window the user was in before opening dooing
+	if constants.previous_win and vim.api.nvim_win_is_valid(constants.previous_win) then
+		vim.api.nvim_set_current_win(constants.previous_win)
+	end
+	constants.previous_win = nil
 end
 
 -- Update window title without recreating the window


### PR DESCRIPTION
When opening a sub-window inside dooing (e.g. the scratchpad), closing dooing afterwards jumps the cursor to the first window in the current tab instead of returning to the window the user was in before opening dooing.

**Repro steps:**
1. Open a file in a split (so you have multiple windows)
2. Open dooing from one of the windows
3. Open the scratchpad for any todo item, then close it
4. Close dooing with `q`
5. **Actual:** focus jumps to the first window in the tab
6. **Expected:** focus returns to the window you were in at step 2

### Root Cause

Dooing relied on Neovim's implicit alternate-window tracking to return focus after closing. Opening any intermediate floating window (scratchpad, tags, search) clobbers that tracking, so Neovim has no record of the original window to return to.

### Fix

Explicitly save the user's window ID in `constants.previous_win` before creating the dooing window, and restore focus to it in `close_window()`.

A guard ensures the saved ID isn't overwritten when the window is already open (e.g. when switching between global and project todos).

**Changes:**
- `lua/dooing/ui/constants.lua` — added `previous_win` field 
- `lua/dooing/ui/window.lua` — save window ID in `create_window()`, restore it   in `close_window()`
