### PR TITLE
fix: handle nil input when aborting sub-task creation

### DIFF
--- a/lua/dooing/ui/actions.lua
+++ b/lua/dooing/ui/actions.lua
@@ -399,8 +399,11 @@ function M.new_nested_todo()
 	end
 	
 	vim.ui.input({ prompt = "New sub-task: " }, function(input)
+		if not input or input == "" then
+			return
+		end
 		input = input:gsub("\n", " ")
-		if input and input ~= "" then
+		if input ~= "" then
 			-- Check if priorities are configured
 			if config.options.priorities and #config.options.priorities > 0 then
 				local priorities = config.options.priorities


### PR DESCRIPTION
**Bug**

Pressing `<Esc>` to abort the `vim.ui.input` prompt when creating a nested sub-task (`<leader>tn`) causes an error:

```
E5108: Error executing lua: .../lua/dooing/ui/actions.lua:402: attempt to index local 'input' (a nil value)
```

**Cause**

In `ui/actions.lua`, the `vim.ui.input` callback calls `input:gsub("\n", " ")` *before* checking whether `input` is `nil`. When the user cancels the prompt, `input` is `nil`, and the `:gsub()` call crashes.

**Fix**

Added an early return guard at the top of the callback to exit gracefully when `input` is `nil` or empty, before any further processing.

**How to reproduce**

1. Open Dooing (`:Dooing`)
2. Create a task and navigate to it
3. Press `<leader>tn` to create a sub-task
4. Press `<Esc>` to cancel — error is thrown without this fix
