### PR TITLE
feat(config): combine window size into adaptive `dimensions` option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ Todos are stored as a **flat JSON array** in a single file (default: `vim.fn.std
 - All runtime access goes through `config.options.*`
 - Keymaps can be disabled by setting them to `false` (checked in `init.lua` before `vim.keymap.set`)
 - When adding a new config option: add default to `M.defaults`, access via `config.options.your_option`
+- **Window size (`window.dimensions`):** may be a table `{ width = <n>, height = <n> }` **or** a function returning such a table (evaluated on every window creation, so sizes can adapt to `vim.o.columns` / `vim.o.lines`). Never read `config.options.window.dimensions` directly — call `config.get_window_dimensions()`, which resolves the function form, accepts positional `{ <w>, <h> }` tables, floors/clamps to the editor size, and falls back to `{ width = 55, height = 20 }` on invalid values
+- The legacy `window.width` / `window.height` options are deprecated: `M.setup()` folds user-supplied values into `window.dimensions` (with a `vim.notify` warning) and removes the legacy keys from `config.options.window`
 
 ## Code Conventions
 
@@ -116,6 +118,7 @@ Todos are stored as a **flat JSON array** in a single file (default: `vim.fn.std
 
 - **Duplicate function definitions in `state.lua`:** `delete_todo()` and `delete_completed()` are defined twice — the second definitions (near the bottom) override the first to add undo support. This is intentional.
 - **`---@diagnostic disable` lines** at the top of UI files suppress known warnings — don't remove them.
+- **`window.width` / `window.height` no longer exist at runtime** — they are migrated into `window.dimensions` during `config.setup()`. Any new code needing the window size must use `config.get_window_dimensions()` (consumers: `ui/window.lua`, `ui/rendering.lua`, `ui/due_notification.lua`).
 - **Git root detection** uses `io.popen("git rev-parse --show-toplevel")` — synchronous/blocking. Keep this in mind for performance.
 - **No automated tests** — verify changes manually with various configurations, empty/full todo lists, and nested task scenarios. Check `:messages` for Lua errors.
 - **`server.lua`** is a standalone QR-code share feature using raw TCP (`vim.loop`). It's isolated and rarely needs changes.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ Dooing comes with sensible defaults that you can override:
 
     -- Window settings
     window = {
-        width = 55,         -- Width of the floating window
-        height = 20,        -- Height of the floating window
+        -- Size of the floating window; may also be a function returning a
+        -- table with these keys (see "Adaptive Window Size" below)
+        dimensions = {
+            width = 55,     -- Width of the floating window
+            height = 20,    -- Height of the floating window
+        },
         border = 'rounded', -- Border style: 'single', 'double', 'rounded', 'solid'
         zindex = 50,        -- Base z-index for floating windows (uses zindex to zindex+5)
         position = 'center', -- Window position: 'right', 'left', 'top', 'bottom', 'center',
@@ -218,6 +222,34 @@ Dooing comes with sensible defaults that you can override:
     done_sort_by_completed_time = false,
 }
 ```
+
+### Adaptive Window Size
+
+`window.dimensions` accepts either a table or a **function** returning one. The
+function is evaluated every time the todo window is opened, so the window can
+adapt to the current editor size:
+
+```lua
+require("dooing").setup({
+    window = {
+        dimensions = function()
+            return {
+                width = math.max(40, math.floor(vim.o.columns * 0.4)),
+                height = math.max(10, math.floor(vim.o.lines * 0.6)),
+            }
+        end,
+    },
+})
+```
+
+Values are floored and clamped to the space available in the editor. If the
+function raises an error or returns something unusable, Dooing falls back to
+`{ width = 55, height = 20 }`.
+
+> [!NOTE]
+> The former `window.width` / `window.height` options are deprecated but still
+> honoured: they are folded into `window.dimensions` (with a warning), so
+> existing configurations keep working.
 
 ## 📂 Per-Project Todos
 

--- a/doc/dooing.txt
+++ b/doc/dooing.txt
@@ -8,6 +8,7 @@ Table of Contents                                          *dooing-contents*
   - Requirements                                          |dooing-requirements|
   - Installation                                          |dooing-installation|
   - Configuration                                        |dooing-configuration|
+  - Adaptive Window Size                                |dooing-adaptive-size|
   - Usage                                                        |dooing-usage|
   - Commands                                                  |dooing-commands|
   - Keybindings                                            |dooing-keybindings|
@@ -62,8 +63,10 @@ The plugin can be configured by passing a table to the setup function:
 >
     require('dooing').setup({
         window = {
-            width = 55,                -- Width of the todo window
-            height = 20,               -- Height of the todo window
+            dimensions = {             -- Size of the todo window; may also be
+                width = 55,            -- a function returning a table with
+                height = 20,           -- these keys, see
+            },                         -- |dooing-adaptive-size|
             border = "rounded",        -- Border style
             zindex = 50,               -- Base z-index for floating windows
                                        -- Dooing uses zindex to zindex+5 for layering:
@@ -111,6 +114,31 @@ The plugin can be configured by passing a table to the setup function:
         },
     })
 <
+
+ADAPTIVE WINDOW SIZE                                    *dooing-adaptive-size*
+
+`window.dimensions` accepts either a table or a function returning one. The
+function is evaluated every time the todo window is opened, so the size can
+adapt to the current editor dimensions:
+>
+    require("dooing").setup({
+        window = {
+            dimensions = function()
+                return {
+                    width = math.max(40, math.floor(vim.o.columns * 0.4)),
+                    height = math.max(10, math.floor(vim.o.lines * 0.6)),
+                }
+            end,
+        },
+    })
+<
+Values are floored and clamped to the space available in the editor. If the
+function raises an error or returns something unusable, Dooing falls back to
+`{ width = 55, height = 20 }`.
+
+The former `window.width` and `window.height` options are deprecated but still
+honoured: they are folded into `window.dimensions` (with a warning) so that
+existing configurations keep working.
 
 
 USAGE                                                          *dooing-usage*

--- a/lua/dooing/config.lua
+++ b/lua/dooing/config.lua
@@ -3,8 +3,17 @@ local M = {}
 
 M.defaults = {
 	window = {
-		width = 55,
-		height = 20,
+		-- Size of the todo window: either a table `{ width = <n>, height = <n> }`
+		-- or a function returning such a table. The function form is evaluated every
+		-- time the window is opened, which allows sizes that adapt to the current
+		-- editor dimensions, e.g.
+		--   dimensions = function()
+		--     return { width = math.floor(vim.o.columns * 0.4), height = math.floor(vim.o.lines * 0.6) }
+		--   end
+		dimensions = {
+			width = 55,
+			height = 20,
+		},
 		border = "rounded",
 		zindex = 50,
 		position = "center",
@@ -137,8 +146,100 @@ M.defaults = {
 
 M.options = {}
 
+-- Used when `window.dimensions` cannot be resolved to usable values
+local FALLBACK_DIMENSIONS = { width = 55, height = 20 }
+
+-- Extracts width/height from a dimensions table, accepting both the named form
+-- `{ width = 55, height = 20 }` and the positional form `{ 55, 20 }`
+local function unpack_dimensions(value)
+	if type(value) ~= "table" then
+		return nil
+	end
+	local width = value.width or value[1]
+	local height = value.height or value[2]
+	if type(width) ~= "number" or type(height) ~= "number" then
+		return nil
+	end
+	return { width = width, height = height }
+end
+
+-- Folds the deprecated `window.width` / `window.height` options into
+-- `window.dimensions` so that existing user configurations keep working
+local function migrate_legacy_dimensions(opts)
+	local user_window = opts and opts.window
+	if type(user_window) ~= "table" then
+		return
+	end
+	if user_window.width == nil and user_window.height == nil then
+		return
+	end
+
+	-- An explicit `dimensions` always wins over the legacy keys
+	if user_window.dimensions == nil then
+		local defaults = M.defaults.window.dimensions
+		M.options.window.dimensions = {
+			width = user_window.width or defaults.width,
+			height = user_window.height or defaults.height,
+		}
+	end
+
+	-- Drop the legacy keys to keep a single source of truth
+	M.options.window.width = nil
+	M.options.window.height = nil
+
+	vim.notify(
+		"dooing: `window.width` / `window.height` are deprecated, use "
+			.. "`window.dimensions = { width = <n>, height = <n> }` instead "
+			.. "(a function returning such a table is also supported)",
+		vim.log.levels.WARN
+	)
+end
+
+---Resolves `window.dimensions` into concrete cell counts.
+---
+---`window.dimensions` may be either
+---  * a table:    `{ width = 55, height = 20 }`, or
+---  * a function: `function() return { width = ..., height = ... } end`
+---
+---The function form is evaluated on every call, so the returned size may depend
+---on the current editor dimensions (`vim.o.columns` / `vim.o.lines`).
+---@return { width: integer, height: integer }
+function M.get_window_dimensions()
+	local value = (M.options.window or {}).dimensions
+
+	if type(value) == "function" then
+		local ok, result = pcall(value)
+		if not ok then
+			vim.notify("dooing: `window.dimensions` function failed: " .. tostring(result), vim.log.levels.ERROR)
+			result = nil
+		end
+		value = result
+	end
+
+	local dimensions = unpack_dimensions(value)
+	if not dimensions then
+		if value ~= nil then
+			vim.notify(
+				"dooing: `window.dimensions` must be (or return) a table "
+					.. "`{ width = <n>, height = <n> }`; falling back to defaults",
+				vim.log.levels.WARN
+			)
+		end
+		dimensions = FALLBACK_DIMENSIONS
+	end
+
+	-- Clamp to the space actually available, keeping at least one cell
+	local max_width = math.max(vim.o.columns, 1)
+	local max_height = math.max(vim.o.lines - 4, 1) -- room for borders, statusline and cmdline
+	return {
+		width = math.min(math.max(math.floor(dimensions.width), 1), max_width),
+		height = math.min(math.max(math.floor(dimensions.height), 1), max_height),
+	}
+end
+
 function M.setup(opts)
 	M.options = vim.tbl_deep_extend("force", M.defaults, opts or {})
+	migrate_legacy_dimensions(opts)
 end
 
 return M

--- a/lua/dooing/ui/due_notification.lua
+++ b/lua/dooing/ui/due_notification.lua
@@ -84,7 +84,8 @@ function M.show_due_notification()
 	-- Get formatting config
 	local formatting = config.options.formatting
 	local lang = calendar.get_language()
-	local window_width = config.options.window.width
+	local dimensions = config.get_window_dimensions()
+	local window_width = dimensions.width
 	local notes_icon = config.options.notes.icon
 	
 	-- Render each due todo
@@ -116,7 +117,7 @@ function M.show_due_notification()
 	
 	-- Calculate window dimensions
 	local ui = vim.api.nvim_list_uis()[1]
-	local width = config.options.window.width
+	local width = dimensions.width
 	local height = math.min(#lines + 2, math.floor(ui.height * 0.6))
 	local position = config.options.window.position or "center"
 	local padding = 2

--- a/lua/dooing/ui/rendering.lua
+++ b/lua/dooing/ui/rendering.lua
@@ -138,7 +138,7 @@ function M.render_todos()
 	local in_progress_icon = config.options.formatting.in_progress.icon
 
 	-- Get window width for timestamp positioning
-	local window_width = config.options.window.width
+	local window_width = config.get_window_dimensions().width
 	
 	-- Loop through all todos and render them using the format
 	for _, todo in ipairs(state.todos) do

--- a/lua/dooing/ui/window.lua
+++ b/lua/dooing/ui/window.lua
@@ -196,8 +196,9 @@ function M.create_window()
 	end
 
 	local ui = vim.api.nvim_list_uis()[1]
-	local width = config.options.window.width
-	local height = config.options.window.height
+	local dimensions = config.get_window_dimensions()
+	local width = dimensions.width
+	local height = dimensions.height
 	local main_border_height = 2 -- top + bottom border
 	local position = config.options.window.position or "right"
 


### PR DESCRIPTION
Replace the flat `window.width` / `window.height` options with a single `window.dimensions`, which accepts either a table `{ width = <n>, height = <n> }` or a function returning one. The function form is evaluated on every window creation, so the todo window can size itself relative to the current editor dimensions.

Add `config.get_window_dimensions()` as the single resolution point: it evaluates the function form under `pcall`, accepts named and positional tables, floors and clamps values to the available editor space, and falls back to 55x20 with a warning on invalid input. `ui/window.lua`, `ui/rendering.lua` and `ui/due_notification.lua` now go through it.

Existing configurations keep working: `setup()` folds user-supplied `window.width` / `window.height` into `window.dimensions` with a deprecation warning and drops the legacy keys.

Docs: README gains an "Adaptive Window Size" section, doc/dooing.txt gains the `dooing-adaptive-size` tag plus a ToC entry, and CLAUDE.md records the new configuration pattern and the accompanying gotcha.