### PR TITLE
Fix tag parsing to allow dashes, underscores, and slashes

### DIFF
--- a/lua/dooing/state.lua
+++ b/lua/dooing/state.lua
@@ -3,6 +3,7 @@ local vim = vim
 
 local M = {}
 local config = require("dooing.config")
+local utils = require("dooing.ui.utils")
 
 -- Cache frequently accessed values
 local priority_weights = {}
@@ -447,7 +448,7 @@ function M.get_all_tags()
 	local seen = {}
 	for _, todo in ipairs(M.todos) do
 		-- Remove unused todo_tags variable
-		for tag in todo.text:gmatch("#(%w+)") do
+		for tag in todo.text:gmatch("#([%w_%-/]+)") do
 			if not seen[tag] then
 				seen[tag] = true
 				table.insert(tags, tag)
@@ -783,9 +784,22 @@ function M.compare_todos_ignore_completion(a, b)
 	return todo_a.created_at < todo_b.created_at
 end
 
+-- A tag is a whole `#[%w_%-/]+` run, so replacing/removing "#labels" must not
+-- touch "#labels-web" (a different tag that merely shares a prefix). Walk
+-- every `#tag` occurrence via the same extraction pattern `get_all_tags`
+-- uses, and only rewrite the ones that are an exact match.
+local function replace_exact_tag(text, tag, replacement)
+	return (text:gsub("#([%w_%-/]+)", function(found)
+		if found == tag then
+			return replacement
+		end
+		return "#" .. found
+	end))
+end
+
 function M.rename_tag(old_tag, new_tag)
 	for _, todo in ipairs(M.todos) do
-		todo.text = todo.text:gsub("#" .. old_tag, "#" .. new_tag)
+		todo.text = replace_exact_tag(todo.text, old_tag, "#" .. new_tag)
 	end
 	save_todos()
 end
@@ -793,8 +807,7 @@ end
 function M.delete_tag(tag)
 	local remaining_todos = {}
 	for _, todo in ipairs(M.todos) do
-		todo.text = todo.text:gsub("#" .. tag .. "(%s)", "%1")
-		todo.text = todo.text:gsub("#" .. tag .. "$", "")
+		todo.text = replace_exact_tag(todo.text, tag, "")
 		table.insert(remaining_todos, todo)
 	end
 	M.todos = remaining_todos
@@ -1007,8 +1020,8 @@ function M.delete_todo_with_confirmation(todo_index, win_id, calendar, callback)
 	vim.api.nvim_buf_add_highlight(confirm_buf, ns, main_hl, 2, 0, #todo_display_text)
 
 	-- Tag highlights
-	for tag in current_todo.text:gmatch("#(%w+)") do
-		local start_idx = todo_display_text:find("#" .. tag)
+	for tag in current_todo.text:gmatch("#([%w_%-/]+)") do
+		local start_idx = todo_display_text:find("#" .. utils.escape_pattern(tag))
 		if start_idx then
 			vim.api.nvim_buf_add_highlight(confirm_buf, ns, "Type", 2, start_idx - 1, start_idx + #tag)
 		end

--- a/lua/dooing/ui/components.lua
+++ b/lua/dooing/ui/components.lua
@@ -6,6 +6,7 @@ local constants = require("dooing.ui.constants")
 local state = require("dooing.state")
 local config = require("dooing.config")
 local calendar = require("dooing.ui.calendar")
+local utils = require("dooing.ui.utils")
 
 -- Creates and manages the help window
 function M.create_help_window()
@@ -258,8 +259,8 @@ local function handle_search_query(query)
     if line:match("%s+[" .. done_icon .. pending_icon .. in_progress_icon .. "]") then
       local hl_group = line:match(done_icon) and "DooingDone" or "DooingPending"
       vim.api.nvim_buf_add_highlight(constants.search_buf_id, constants.ns_id, hl_group, i - 1, 0, -1)
-      for tag in line:gmatch("#(%w+)") do
-        local start_idx = line:find("#" .. tag) - 1
+      for tag in line:gmatch("#([%w_%-/]+)") do
+        local start_idx = line:find("#" .. utils.escape_pattern(tag)) - 1
         vim.api.nvim_buf_add_highlight(constants.search_buf_id, constants.ns_id, "Type", i - 1, start_idx,
           start_idx + #tag + 1)
       end

--- a/lua/dooing/ui/due_notification.lua
+++ b/lua/dooing/ui/due_notification.lua
@@ -210,9 +210,9 @@ function M.show_due_notification()
 					end
 					
 					-- Tags highlight
-					for tag in line:gmatch("#(%w+)") do
+					for tag in line:gmatch("#([%w_%-/]+)") do
 						local tag_pattern = "#" .. tag
-						local start_idx = line:find(tag_pattern)
+						local start_idx = line:find("#" .. utils.escape_pattern(tag))
 						if start_idx then
 							vim.api.nvim_buf_add_highlight(due_buf_id, ns_id, "Type", line_nr, start_idx - 1, start_idx + #tag_pattern - 1)
 						end

--- a/lua/dooing/ui/modern.lua
+++ b/lua/dooing/ui/modern.lua
@@ -256,7 +256,7 @@ local function split_tags(text)
 	local cursor = 1
 
 	while true do
-		local tag_start, tag_end = text:find("#[%w_%-]+", cursor)
+		local tag_start, tag_end = text:find("#[%w_%-/]+", cursor)
 		if not tag_start then
 			break
 		end
@@ -462,7 +462,7 @@ function M.build(todos, active_filter)
 	-- Collect the visible todos, keeping their real index in `state.todos`
 	local visible = {}
 	for index, todo in ipairs(todos) do
-		if not active_filter or todo.text:match("#" .. active_filter) then
+		if not active_filter or utils.has_tag(todo.text, active_filter) then
 			table.insert(visible, { todo = todo, index = index })
 		end
 	end
@@ -604,7 +604,7 @@ function M.stats(todos, active_filter)
 	local now = os.time()
 
 	for _, todo in ipairs(todos) do
-		if not active_filter or todo.text:match("#" .. active_filter) then
+		if not active_filter or utils.has_tag(todo.text, active_filter) then
 			total = total + 1
 			if todo.done then
 				done = done + 1

--- a/lua/dooing/ui/panels.lua
+++ b/lua/dooing/ui/panels.lua
@@ -11,6 +11,7 @@ local M = {}
 local constants = require("dooing.ui.constants")
 local config = require("dooing.config")
 local state = require("dooing.state")
+local utils = require("dooing.ui.utils")
 
 --------------------------------------------------------------------------------
 -- Geometry
@@ -393,7 +394,7 @@ end
 local function tag_count(tag)
 	local count = 0
 	for _, todo in ipairs(state.todos) do
-		if todo.text:match("#" .. tag .. "%f[%W]") then
+		if utils.has_tag(todo.text, tag) then
 			count = count + 1
 		end
 	end
@@ -585,7 +586,7 @@ local function show_results(query, results)
 		local text_start = 2 + #icon + 1
 		table.insert(spans, { line = line_nr, start_col = text_start, end_col = #line, hl_group = base_hl })
 
-		for tag_start, tag in text:gmatch("()(#[%w_%-]+)") do
+		for tag_start, tag in text:gmatch("()(#[%w_%-/]+)") do
 			local from = text_start + tag_start - 1
 			table.insert(spans, { line = line_nr, start_col = from, end_col = from + #tag, hl_group = "DooingTag" })
 		end

--- a/lua/dooing/ui/rendering.lua
+++ b/lua/dooing/ui/rendering.lua
@@ -221,7 +221,7 @@ function M.render_todos(opts)
 	
 	-- Loop through all todos and render them using the format
 	for _, todo in ipairs(state.todos) do
-		if not state.active_filter or todo.text:match("#" .. state.active_filter) then
+		if not state.active_filter or utils.has_tag(todo.text, state.active_filter) then
 			-- use the appropriate format based on the todo's status and lang
 			if todo.notes == nil or todo.notes == "" then
 				tmp_notes_icon = ""
@@ -264,7 +264,7 @@ function M.render_todos(opts)
 	local line_offset = state.active_filter and 3 or 1
 	local visible_count = 0
 	for index, todo in ipairs(state.todos) do
-		if not state.active_filter or todo.text:match("#" .. state.active_filter) then
+		if not state.active_filter or utils.has_tag(todo.text, state.active_filter) then
 			visible_count = visible_count + 1
 			classic_map[line_offset + visible_count] = index
 			classic_primary[index] = line_offset + visible_count
@@ -304,9 +304,9 @@ function M.render_todos(opts)
 				end
 
 				-- Tags highlight
-				for tag in line:gmatch("#(%w+)") do
+				for tag in line:gmatch("#([%w_%-/]+)") do
 					local tag_pattern = "#" .. tag
-					local start_idx = line:find(tag_pattern) - 1
+					local start_idx = line:find("#" .. utils.escape_pattern(tag)) - 1
 					add_hl(line_nr, start_idx, start_idx + #tag_pattern, "Type")
 				end
 

--- a/lua/dooing/ui/utils.lua
+++ b/lua/dooing/ui/utils.lua
@@ -6,6 +6,26 @@ local calendar = require("dooing.ui.calendar")
 local config = require("dooing.config")
 local constants = require("dooing.ui.constants")
 
+-- Escapes Lua pattern magic characters so a string containing e.g. "-" or
+-- "/" can be spliced into a match/find/gsub pattern and matched literally.
+function M.escape_pattern(text)
+	return (text:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1"))
+end
+
+-- Tags are `#[%w_%-/]+` runs. Matching a tag by splicing it into a pattern
+-- (even escaped) is a substring test, so filtering by "#labels" would also
+-- match "#labels-web" — a different tag that merely shares a prefix. Extract
+-- every tag the same way `get_all_tags` does and compare for equality
+-- instead, so a tag is only ever "found" as a whole token.
+function M.has_tag(text, tag)
+	for found in text:gmatch("#([%w_%-/]+)") do
+		if found == tag then
+			return true
+		end
+	end
+	return false
+end
+
 -- Resolves a 1-based buffer line in the main window to an index into
 -- `state.todos`. Goes through the map the renderer builds, which is what lets
 -- the list contain lines that are not todos (section headers, metadata
@@ -26,7 +46,7 @@ function M.todo_index_at_line(line)
 	if state.active_filter then
 		local visible_index = 0
 		for i, todo in ipairs(state.todos) do
-			if todo.text:match("#" .. state.active_filter) then
+			if M.has_tag(todo.text, state.active_filter) then
 				visible_index = visible_index + 1
 				if visible_index == line - 3 then
 					return i


### PR DESCRIPTION
## Description

Tags were extracted with `#(%w+)`, which only matches alphanumerics in Lua patterns. `#due-soon` silently truncated to `#due`, dropping `-soon`. Widened the character class to `[%w_%-/]+` across all extraction sites, so dashes, underscores, and slashes work too (useful for hierarchical tags like `#project/frontend`).

That surfaced a second bug: filtering, counting, and renaming spliced the raw tag into a match/find/gsub pattern, so `-` and other pattern-magic characters broke matching outright, and worse, a plain substring match meant filtering by `#due` also matched `#due-soon`. Added `has_tag` in `ui/utils.lua`, which re-extracts tags the same way and compares for equality instead of building ad-hoc patterns. Rewrote `rename_tag`/`delete_tag` to do the same exact-match walk rather than gsub a spliced pattern.

Position lookups (finding where an already-extracted tag sits in a line, for highlighting) still use `escape_pattern` + `find`, since that's a genuine substring search on a known-safe string, not a filter.

This means tags like `#due-soon` and `#code-review` now keep their full name instead of truncating at the dash, and slash lets you nest tags for structure, e.g. `#project/frontend` for a sub-area under a bigger one.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Manual testing performed
- [x] No Lua errors
- [x] All existing features work
- [x] New features work as expected

## Documentation
- [ ] Updated README.md (if applicable)
- [ ] Updated doc/dooing.txt (if applicable)
- [ ] Updated keymaps documentation (if applicable)
